### PR TITLE
Upgrade to Netty4 4.1.51.Final and Netty4StaticSsl 2.0.33.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ val releaseVersion = "20.9.0-SNAPSHOT"
 
 val libthriftVersion = "0.10.0"
 
-val defaultNetty4Version = "4.1.47.Final"
-val defaultNetty4StaticSslVersion = "2.0.30.Final"
+val defaultNetty4Version = "4.1.51.Final"
+val defaultNetty4StaticSslVersion = "2.0.33.Final"
 
 val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") match {
   case Some(useSnapshot) => useSnapshot.toBoolean

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LossyEmaTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LossyEmaTest.scala
@@ -45,16 +45,17 @@ class LossyEmaTest extends FunSuite {
   test("update over durations greater than window") {
     Time.withCurrentTimeFrozen { tc =>
       val value = 100.0
+      val tolerance = 0.000000000000025
       val ema = new LossyEma(300.millis.inMillis, Stopwatch.timeMillis, value)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 71.65313105737893)
+      assert((ema.update(0.0) - 71.65313105737893).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 51.34171190325921)
+      assert((ema.update(0.0) - 51.34171190325921).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 36.787944117144235)
+      assert((ema.update(0.0) - 36.787944117144235).abs <= tolerance)
 
       tc.advance(100.millis)
       assert(ema.update(0.0) == 26.35971381157268)


### PR DESCRIPTION
Hi

Package Owner: Abhishek kumar nishant

PR change Details:
$Patch Details : Following file has been modified:

.build.sbt:
Modified build.sbt to update Netty4 version from '4.1.47.Final' to '4.1.50.Final' and Netty4StaticSsl version from '2.0.30.Final' to '2.0.31.Final'.
Modified LossyEmaTest.scala present at /finagle-core/src/test/scala/com/twitter/finagle/util/LossyEmaTest.scala to make this test case compatible with aarch64.

+      val tolerance = 0.000000000000025
       val ema = new LossyEma(300.millis.inMillis, Stopwatch.timeMillis, value)

       tc.advance(100.millis)
-      assert(ema.update(0.0) == 71.65313105737893)
+      assert((ema.update(0.0) - 71.65313105737893).abs <= tolerance)

       tc.advance(100.millis)
-      assert(ema.update(0.0) == 51.34171190325921)
+      assert((ema.update(0.0) - 51.34171190325921).abs <= tolerance)

       tc.advance(100.millis)
-      assert(ema.update(0.0) == 36.787944117144235)
+      assert((ema.update(0.0) - 36.787944117144235).abs <= tolerance)

$Testing Detail:

After doing the changes,verified working by executing './sbt 'project Finagle core' test' command and all test cases are running fine on x86 and aarch64 both platforms

$PR Description :Here is my commit message :

Upgrade Netty4 to its latest version 4.1.50.Final and Netty4StaticSsl to its latest version(2.0.31.Final) for both security fixes and AArch64 performance improvements

Body

The update Netty4 ver 4.1.50 and Netty4StaticSsl ver 2.0.31.Final includes both security fixes and AArch64 performance improvements

Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html
Added tolerance in file LossyEmaTest.scala to make it compatible with aarch64.

Signed-off-by: odidev odidev@puresoftware.com

$ Peer Reviewer: Shweta Singh
$ Reviewer: Shobhit Parashri

